### PR TITLE
Bugfix: `tpub-update`did not show ArXiv articles

### DIFF
--- a/tpub/tpub.py
+++ b/tpub/tpub.py
@@ -490,7 +490,7 @@ class PublicationDB(object):
 
             # Ignore all the unrefereed non-arxiv stuff
             try:
-                if "NOT REFEREED" in article.property and article.pub != "ArXiv e-prints":
+                if "NOT REFEREED" in article.property and article.pub.lower() != "arxiv e-prints":
                     ignore = True
             except (AttributeError, TypeError, ads.exceptions.APIResponseError):
                 pass  # no .pub attribute


### PR DESCRIPTION
The `pub` field returned by the ADS API recently changed from "**a**rXiv e-prints" into "**A**rXiv e-prints" for arxiv papers (note the lowercase "a").  As a result, the `tpub-update` command was ignoring arxiv papers. This PR resolves the issue and enables ArXiv papers to be included again.